### PR TITLE
Add date in resource API responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opendocsg/pdf2md": "^0.1.31",
-        "@sentry/node": "^8.36.0",
+        "@sentry/node": "^8.39.0",
         "axios": "^1.7.7",
         "body-parser": "^1.20.2",
         "bull": "^4.16.4",
@@ -23,13 +23,13 @@
         "express-openapi-validator": "^5.3.9",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.21",
-        "marked": "^14.1.3",
+        "marked": "^15.0.1",
         "nanoid": "^3.3.7",
         "nconf": "^0.12.1",
-        "newrelic": "^12.6.0",
+        "newrelic": "^12.8.0",
         "node-html-markdown": "^1.3.0",
         "nunjucks": "^3.2.4",
-        "openai": "^4.71.0",
+        "openai": "^4.72.0",
         "pg": "^8.13.1",
         "pg-hstore": "^2.3.4",
         "pgvector": "^0.2.0",
@@ -41,7 +41,7 @@
         "tiktoken": "^1.0.17",
         "wink-eng-lite-web-model": "^1.8.0",
         "wink-nlp": "^2.3.0",
-        "winston": "^3.16.0"
+        "winston": "^3.17.0"
       },
       "devDependencies": {
         "eslint": "^8.57.1",
@@ -2829,14 +2829,43 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.42.0.tgz",
-      "integrity": "sha512-fiuU6OKsqHJiydHWgTRQ7MnIrJ2lEqsdgFtNIH4LbAUJl/5XmrIeoDzDnox+hfkgWK65jsleFuQDtYb5hW1koQ==",
-      "license": "Apache-2.0",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.43.0.tgz",
+      "integrity": "sha512-ALjfQC+0dnIEcvNYsbZl/VLh7D2P1HhFF4vicRKHhHFIUV3Shpg4kXgiek5PLhmeKSIPiUB25IYH5RIneclL4A==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation": "^0.54.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-amqplib/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -2954,14 +2983,43 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.40.0.tgz",
-      "integrity": "sha512-74qj4nG3zPtU7g2x4sm2T4R3/pBMyrYstTsqSZwdlhQk1SD4l8OSY9sPRX1qkhfxOuW3U4KZQAV/Cymb3fB6hg==",
-      "license": "Apache-2.0",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.41.0.tgz",
+      "integrity": "sha512-pNRjFvf0mvqfJueaeL/qEkuGJwgtE5pgjIHGYwjc2rMViNCrtY9/Sf+Nu8ww6dDd/Oyk2fwZZP7i0XZfCnETrA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation": "^0.54.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fastify/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-fastify/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -3031,12 +3089,41 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.43.0.tgz",
-      "integrity": "sha512-aI3YMmC2McGd8KW5du1a2gBA0iOMOGLqg4s9YjzwbjFwjlmMNFSK1P3AIg374GWg823RPUGfVTIgZ/juk9CVOA==",
-      "license": "Apache-2.0",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.44.0.tgz",
+      "integrity": "sha512-FYXTe3Bv96aNpYktqm86BFUTpjglKD0kWI5T5bxYkLUPEPvFn38vWGMJTGrDMVou/i55E4jlWvcm6hFIqLsMbg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.53.0"
+        "@opentelemetry/instrumentation": "^0.54.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-graphql/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -3157,6 +3244,51 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-knex": {
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.41.0.tgz",
+      "integrity": "sha512-OhI1SlLv5qnsnm2dOVrian/x3431P75GngSpnR7c4fcVFv7prXGYu29Z6ILRWJf/NJt6fkbySmwdfUUnFnHCTg==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-knex/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-koa": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.43.0.tgz",
@@ -3190,14 +3322,42 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.47.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.47.0.tgz",
-      "integrity": "sha512-yqyXRx2SulEURjgOQyJzhCECSh5i1uM49NUaq9TqLd6fA7g26OahyJfsr9NE38HFqGRHpi4loyrnfYGdrsoVjQ==",
-      "license": "Apache-2.0",
+      "version": "0.48.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.48.0.tgz",
+      "integrity": "sha512-9YWvaGvrrcrydMsYGLu0w+RgmosLMKe3kv/UNlsPy8RLnCkN2z+bhhbjjjuxtUmvEuKZMCoXFluABVuBr1yhjw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/sdk-metrics": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.54.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
       },
       "engines": {
         "node": ">=14"
@@ -3309,6 +3469,52 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-tedious": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.15.0.tgz",
+      "integrity": "sha512-Kb7yo8Zsq2TUwBbmwYgTAMPK0VbhoS8ikJ6Bup9KrDtCx2JC01nCb+M0VJWXt7tl0+5jARUbKWh5jRSoImxdCw==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/tedious": "^4.0.14"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-tedious/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-undici": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.6.0.tgz",
@@ -3348,22 +3554,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.27.0.tgz",
-      "integrity": "sha512-JzWgzlutoXCydhHWIbLg+r76m+m3ncqvkCcsswXAQ4gqKS+LOHKhq+t6fx1zNytvLuaOUBur7EvWxECc4jPQKg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.27.0",
-        "@opentelemetry/resources": "1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
@@ -3539,70 +3729,102 @@
       "license": "MIT"
     },
     "node_modules/@sentry/core": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.36.0.tgz",
-      "integrity": "sha512-cbq1WQyRqc/+YpPhjwQxfniUM3ZxmO3Pm1oisTB8dw6mlbgQfGD6aznEIjXWWJY6k6acewJlMUx09N7DnprtBw==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.39.0.tgz",
+      "integrity": "sha512-rg2mHtwdCaedqub7bd+ht08vZgtwPO7el5m5sPNeb7V75GcQwSziu6G02vGxCBCsAHpoFn1A+0JLEajaYzZI7w==",
       "dependencies": {
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@sentry/types": "8.39.0",
+        "@sentry/utils": "8.39.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.36.0.tgz",
-      "integrity": "sha512-2RRbSck90TGpVz8F3OaNbq5Q9RXgeRlq5leGWHU7NfQOl3LmkG+vkzTbOqPDPZLtiYcw5KQ3G5G+vybrDS6AGg==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.39.0.tgz",
+      "integrity": "sha512-poQBV1OG5XdESQQNT/qQzrcPBEsQIuK3kz7cE7MVOcdTqjfWGC+gVYMMjvfBrZ+A1jdLolepMLnEG80OzvHoNA==",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.25.1",
         "@opentelemetry/core": "^1.25.1",
-        "@opentelemetry/instrumentation": "^0.53.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.42.0",
+        "@opentelemetry/instrumentation": "^0.54.0",
+        "@opentelemetry/instrumentation-amqplib": "^0.43.0",
         "@opentelemetry/instrumentation-connect": "0.40.0",
         "@opentelemetry/instrumentation-dataloader": "0.12.0",
         "@opentelemetry/instrumentation-express": "0.44.0",
-        "@opentelemetry/instrumentation-fastify": "0.40.0",
+        "@opentelemetry/instrumentation-fastify": "0.41.0",
         "@opentelemetry/instrumentation-fs": "0.16.0",
         "@opentelemetry/instrumentation-generic-pool": "0.39.0",
-        "@opentelemetry/instrumentation-graphql": "0.43.0",
+        "@opentelemetry/instrumentation-graphql": "0.44.0",
         "@opentelemetry/instrumentation-hapi": "0.41.0",
         "@opentelemetry/instrumentation-http": "0.53.0",
         "@opentelemetry/instrumentation-ioredis": "0.43.0",
         "@opentelemetry/instrumentation-kafkajs": "0.4.0",
+        "@opentelemetry/instrumentation-knex": "0.41.0",
         "@opentelemetry/instrumentation-koa": "0.43.0",
         "@opentelemetry/instrumentation-lru-memoizer": "0.40.0",
-        "@opentelemetry/instrumentation-mongodb": "0.47.0",
+        "@opentelemetry/instrumentation-mongodb": "0.48.0",
         "@opentelemetry/instrumentation-mongoose": "0.42.0",
         "@opentelemetry/instrumentation-mysql": "0.41.0",
         "@opentelemetry/instrumentation-mysql2": "0.41.0",
         "@opentelemetry/instrumentation-nestjs-core": "0.40.0",
         "@opentelemetry/instrumentation-pg": "0.44.0",
         "@opentelemetry/instrumentation-redis-4": "0.42.0",
+        "@opentelemetry/instrumentation-tedious": "0.15.0",
         "@opentelemetry/instrumentation-undici": "0.6.0",
         "@opentelemetry/resources": "^1.26.0",
         "@opentelemetry/sdk-trace-base": "^1.26.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@prisma/instrumentation": "5.19.1",
-        "@sentry/core": "8.36.0",
-        "@sentry/opentelemetry": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0",
+        "@sentry/core": "8.39.0",
+        "@sentry/opentelemetry": "8.39.0",
+        "@sentry/types": "8.39.0",
+        "@sentry/utils": "8.39.0",
         "import-in-the-middle": "^1.11.2"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
-    "node_modules/@sentry/opentelemetry": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.36.0.tgz",
-      "integrity": "sha512-pMKMphH0j1Mh8zknLWEEUaaaxeYn76rniGOxKLoQVk1pCUhhzkFEJdxKC41aR8yin/uN8X3CGWQb9vp/przwSg==",
+    "node_modules/@sentry/node/node_modules/@opentelemetry/api-logs": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
+      "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
       "dependencies": {
-        "@sentry/core": "8.36.0",
-        "@sentry/types": "8.36.0",
-        "@sentry/utils": "8.36.0"
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.54.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
+      "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.54.2",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.2",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.39.0.tgz",
+      "integrity": "sha512-ZnZ6zpyRPOUR6LwmvXqXK6XXDfjIXIRoX1ZVy44ZqN3XQL1Cg5n5sp0W/8T0qpKVyyEkE+AphLI/EGyp/gQLfQ==",
+      "dependencies": {
+        "@sentry/core": "8.39.0",
+        "@sentry/types": "8.39.0",
+        "@sentry/utils": "8.39.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -3610,25 +3832,25 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.25.1",
-        "@opentelemetry/instrumentation": "^0.53.0",
+        "@opentelemetry/instrumentation": "^0.54.0",
         "@opentelemetry/sdk-trace-base": "^1.26.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
       }
     },
     "node_modules/@sentry/types": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.36.0.tgz",
-      "integrity": "sha512-K1pVFfdGHw115RzGHpwSOqoEPeayn4N1F9IfM0kxrYpQSbFT1X29eak88GBfC8gPiLEF0iFGlSaQ4ERmF7oRcA==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.39.0.tgz",
+      "integrity": "sha512-/n1bGkbJcSLZQpzd1Oksi8LFAMbcO8j/d+N8mcXS74GuhGgkxQiEwHF2CKTz6SHt8J4hrlyzqIwVzCevUOxZ2Q==",
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "8.36.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.36.0.tgz",
-      "integrity": "sha512-oJ3EDPj0I00z+AwC3EWBpSidXYUoKW0Id8MfMQP5Hflniz3gif7UEReblT+FJgPEVo6+6uNzAncY0MuNMxmDKQ==",
+      "version": "8.39.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.39.0.tgz",
+      "integrity": "sha512-pIBnr/cROds92CcYWBW3z1zFH4uJkMPL2AxEv/ZcLg/NTb1Okz/ZaDP+NMzUfzriYvFBOFk0wPk0h5sYx6Umqw==",
       "dependencies": {
-        "@sentry/types": "8.36.0"
+        "@sentry/types": "8.39.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -4575,6 +4797,14 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/tedious": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
+      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -6185,10 +6415,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -10111,10 +10340,9 @@
       "license": "MIT"
     },
     "node_modules/logform": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.1.tgz",
-      "integrity": "sha512-CdaO738xRapbKIMVn2m4F6KTj4j7ooJ8POVnebSgKo3KBz5axNXRAL7ZdRjIV6NOr2Uf4vjtRkxrFETOioCqSA==",
-      "license": "MIT",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dependencies": {
         "@colors/colors": "1.6.0",
         "@types/triple-beam": "^1.3.2",
@@ -10194,10 +10422,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "14.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.3.tgz",
-      "integrity": "sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==",
-      "license": "MIT",
+      "version": "15.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.1.tgz",
+      "integrity": "sha512-VnnE19XO2Vb2oZeH8quAepfrb6Aaz4OoY8yZQACfuy/5KVJ0GxYC0Qxzz/iuc+g5UF7H0HJ+QROfvH26XeBdDA==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10610,9 +10837,9 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-12.6.0.tgz",
-      "integrity": "sha512-MS3Grlul/HYWv2X3A4U+n0MduWqPaS9X6VbP7JpyhkH1lbO/T0G3rxdgUpDFjjlanxAT1exwWtvtEJ8IiwlJKw==",
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-12.8.0.tgz",
+      "integrity": "sha512-1REYljpk3I1TUI/+EjO4G274ZvXiJVLTHiYh5xnTfnQs79UF51UOp1+AUI+G+gFASo2U5Oi/L3rakGJdtqJeHQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.12.2",
         "@grpc/proto-loader": "^0.7.5",
@@ -11146,9 +11373,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.71.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.71.0.tgz",
-      "integrity": "sha512-jeJ7+6cZvj+ZbIsbX/Ag8+pug2+vjKbrD/v3Hwp6uv3KZyWjSkZa5MdUshzpNC3jsFzakfbUhEEFQXsKWNgm/g==",
+      "version": "4.72.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.72.0.tgz",
+      "integrity": "sha512-hFqG9BWCs7L7ifrhJXw7mJXmUBr7d9N6If3J9563o0jfwVA4wFANFDDaOIWFdgDdwgCXg5emf0Q+LoLCGszQYA==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -14076,38 +14303,50 @@
       "license": "MIT"
     },
     "node_modules/winston": {
-      "version": "3.16.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.16.0.tgz",
-      "integrity": "sha512-xz7+cyGN5M+4CmmD4Npq1/4T+UZaz7HaeTlAruFUTjk79CNMq+P6H30vlE4z0qfqJ01VHYQwd7OZo03nYm/+lg==",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
+      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.6.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.7.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
       }
     },
     "node_modules/winston-transport": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.8.0.tgz",
-      "integrity": "sha512-qxSTKswC6llEMZKgCQdaWgDuMJQnhuvF5f2Nk3SNXc4byfQ+voo2mX1Px9dkNOuR8p0KAjfPG29PuYUSIb+vSA==",
-      "license": "MIT",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "dependencies": {
-        "logform": "^2.6.1",
-        "readable-stream": "^4.5.2",
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
         "triple-beam": "^1.3.0"
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/winston/node_modules/readable-stream": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@opendocsg/pdf2md": "^0.1.31",
-    "@sentry/node": "^8.36.0",
+    "@sentry/node": "^8.39.0",
     "axios": "^1.7.7",
     "body-parser": "^1.20.2",
     "bull": "^4.16.4",
@@ -33,13 +33,13 @@
     "express-openapi-validator": "^5.3.9",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",
-    "marked": "^14.1.3",
+    "marked": "^15.0.1",
     "nanoid": "^3.3.7",
     "nconf": "^0.12.1",
-    "newrelic": "^12.6.0",
+    "newrelic": "^12.8.0",
     "node-html-markdown": "^1.3.0",
     "nunjucks": "^3.2.4",
-    "openai": "^4.71.0",
+    "openai": "^4.72.0",
     "pg": "^8.13.1",
     "pg-hstore": "^2.3.4",
     "pgvector": "^0.2.0",
@@ -51,7 +51,7 @@
     "tiktoken": "^1.0.17",
     "wink-eng-lite-web-model": "^1.8.0",
     "wink-nlp": "^2.3.0",
-    "winston": "^3.16.0"
+    "winston": "^3.17.0"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/src/helpers/serialize.js
+++ b/src/helpers/serialize.js
@@ -9,6 +9,7 @@ function serializeDatasource(model) {
     id: model.resId,
     name: model.name,
     purpose: model.purpose,
+    date: model.createdAt.toISOString(),
   };
 }
 
@@ -23,6 +24,7 @@ function serializeAgent(model) {
     id: model.resId,
     name: model.name,
     purpose: model.purpose,
+    date: model.createdAt.toISOString(),
   };
 }
 
@@ -40,6 +42,7 @@ function serializeDocument(model) {
     status: model.status,
     hash: model.contentHash,
     size: model.contentSize,
+    date: model.createdAt.toISOString(),
     metadata: model.metadata,
   };
 }
@@ -59,6 +62,7 @@ function serializeConnector(model) {
     method: model.method,
     payload: model.payload,
     metadata: model.metadata,
+    date: model.createdAt.toISOString(),
   };
 }
 

--- a/src/v1/agents.js
+++ b/src/v1/agents.js
@@ -32,6 +32,11 @@ module.exports = (router) => {
   *             What this agent is all about.
   *             Make it as descriptive as possible, so that LLM has a good understanding
   *             of the functionality of the agent.
+  *         date:
+  *           type: string
+  *           example: '2024-11-20T06:50:31.958Z'
+  *           description: Agent creation datetime
+  *
   *     NewAgent:
   *       type: object
   *       required:

--- a/src/v1/connectors.js
+++ b/src/v1/connectors.js
@@ -46,6 +46,10 @@ module.exports = (router) => {
   *           type: object
   *           description: API payload parameters.
   *           additionalProperties: true
+  *         date:
+  *           type: string
+  *           example: '2024-11-20T06:50:31.958Z'
+  *           description: Connector creation datetime
   *         metadata:
   *           type: object
   *           description: JSON metadata associated with the connector.

--- a/src/v1/datasources.js
+++ b/src/v1/datasources.js
@@ -32,6 +32,10 @@ module.exports = (router) => {
   *           description: |
   *             The purpose of this datasource. Please be as descriptive as possible so that LLMs
   *             have a good understanding about the content encapsulated.
+  *         date:
+  *           type: string
+  *           example: '2024-11-20T06:50:31.958Z'
+  *           description: Datasource creation datetime
   *
   *     NewDatasource:
   *       type: object

--- a/src/v1/documents.js
+++ b/src/v1/documents.js
@@ -48,6 +48,10 @@ module.exports = (router) => {
   *           type: integer
   *           example: 50234
   *           description: Document size in bytes.
+  *         date:
+  *           type: string
+  *           example: '2024-11-20T06:50:31.958Z'
+  *           description: Document creation datetime
   *         metadata:
   *           type: object
   *           description: |

--- a/tests/agents.test.js
+++ b/tests/agents.test.js
@@ -35,6 +35,7 @@ describe('Agent API', () => {
           id: TOKEN,
           name: TOKEN,
           purpose: TOKEN,
+          date: res.body.data[0].date,
         }],
       });
     });
@@ -86,6 +87,7 @@ describe('Agent API', () => {
         id: 'new-agent',
         name: 'New Agent',
         purpose: 'A new agent purpose',
+        date: res.body.data.date,
       });
 
       const model = await db.Agent.findOne({
@@ -137,6 +139,7 @@ describe('Agent API', () => {
         id: TOKEN,
         name: TOKEN,
         purpose: TOKEN,
+        date: res.body.data.date,
       });
     });
 
@@ -168,6 +171,7 @@ describe('Agent API', () => {
         id: TOKEN,
         name: 'Updated Agent',
         purpose: 'An updated agent purpose',
+        date: res.body.data.date,
       });
 
       const model = await db.Agent.findOne({
@@ -196,6 +200,7 @@ describe('Agent API', () => {
         id: TOKEN,
         name: 'Updated Agent',
         purpose: factory.agent.purpose,
+        date: res.body.data.date,
       });
     });
 
@@ -215,6 +220,7 @@ describe('Agent API', () => {
         id: TOKEN,
         name: factory.agent.name,
         purpose: 'Updated purpose',
+        date: res.body.data.date,
       });
     });
 
@@ -315,6 +321,7 @@ describe('Agent API', () => {
           id: TOKEN,
           name: TOKEN,
           purpose: TOKEN,
+          date: res.body.data[0].date,
         }],
       });
     });

--- a/tests/connectors.test.js
+++ b/tests/connectors.test.js
@@ -38,6 +38,7 @@ describe('Connectors API', () => {
           endpoint: 'https://www.example.com',
           method: 'get',
           payload: {},
+          date: res.body.data[0].date,
           metadata: {
             foo: 'bar',
           },
@@ -121,6 +122,7 @@ describe('Connectors API', () => {
             description: 'Foo',
           },
         },
+        date: res.body.data.date,
         metadata: { key: 'value' },
       });
 
@@ -184,6 +186,7 @@ describe('Connectors API', () => {
             description: 'Foo',
           },
         },
+        date: res.body.data.date,
         metadata: { key: 'value' },
       });
 

--- a/tests/datasources.test.js
+++ b/tests/datasources.test.js
@@ -35,6 +35,7 @@ describe('Datasources API', () => {
           id: TOKEN,
           name: TOKEN,
           purpose: TOKEN,
+          date: res.body.data[0].date,
         }],
       });
     });
@@ -87,6 +88,7 @@ describe('Datasources API', () => {
         id: 'new-datasource',
         name: 'New Datasource',
         purpose: 'A new datasource purpose',
+        date: res.body.data.date,
       });
 
       const model = await db.Datasource.findOne({
@@ -138,6 +140,7 @@ describe('Datasources API', () => {
         id: TOKEN,
         name: TOKEN,
         purpose: TOKEN,
+        date: res.body.data.date,
       });
     });
 
@@ -169,6 +172,7 @@ describe('Datasources API', () => {
         id: TOKEN,
         name: 'Updated Datasource',
         purpose: 'An updated datasource purpose',
+        date: res.body.data.date,
       });
 
       const model = await db.Datasource.findOne({
@@ -197,6 +201,7 @@ describe('Datasources API', () => {
         id: TOKEN,
         name: 'Updated Datasource',
         purpose: factory.datasource.purpose,
+        date: res.body.data.date,
       });
     });
 
@@ -216,6 +221,7 @@ describe('Datasources API', () => {
         id: TOKEN,
         name: factory.datasource.name,
         purpose: 'Updated purpose',
+        date: res.body.data.date,
       });
     });
 

--- a/tests/documents.test.js
+++ b/tests/documents.test.js
@@ -41,6 +41,7 @@ describe('Documents API', () => {
           size: 4,
           status: 'indexed',
           type: 'text',
+          date: res.body.data[0].date,
         }],
       });
     });


### PR DESCRIPTION
Add `date` field in the API response spec, so that resource creation (agents, datasource,s documents, connectors) is exposed in the API GET requests.