### PR TITLE
Refactor chat endpoint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "func-names": "off",
     "arrow-body-style": "off",
     "no-await-in-loop": "off",
+    "no-bitwise": "off",
     "no-continue": "off"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@opendocsg/pdf2md": "^0.1.31",
-        "@sentry/node": "^8.39.0",
+        "@sentry/node": "^8.40.0",
         "axios": "^1.7.7",
         "body-parser": "^1.20.2",
         "bull": "^4.16.4",
@@ -23,13 +23,12 @@
         "express-openapi-validator": "^5.3.9",
         "ioredis": "^5.4.1",
         "lodash": "^4.17.21",
-        "marked": "^15.0.1",
+        "marked": "^15.0.2",
         "nanoid": "^3.3.7",
         "nconf": "^0.12.1",
         "newrelic": "^12.8.0",
-        "node-html-markdown": "^1.3.0",
         "nunjucks": "^3.2.4",
-        "openai": "^4.72.0",
+        "openai": "^4.73.0",
         "pg": "^8.13.1",
         "pg-hstore": "^2.3.4",
         "pgvector": "^0.2.0",
@@ -39,6 +38,7 @@
         "sequelize-cli": "^6.6.2",
         "swagger-jsdoc": "^6.2.8",
         "tiktoken": "^1.0.17",
+        "turndown": "^7.2.0",
         "wink-eng-lite-web-model": "^1.8.0",
         "wink-nlp": "^2.3.0",
         "winston": "^3.17.0"
@@ -2566,6 +2566,12 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -3729,21 +3735,22 @@
       "license": "MIT"
     },
     "node_modules/@sentry/core": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.39.0.tgz",
-      "integrity": "sha512-rg2mHtwdCaedqub7bd+ht08vZgtwPO7el5m5sPNeb7V75GcQwSziu6G02vGxCBCsAHpoFn1A+0JLEajaYzZI7w==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.40.0.tgz",
+      "integrity": "sha512-u/U2CJpG/+SmTR2bPM4ZZoPYTJAOUuxzj/0IURnvI0v9+rNu939J/fzrO9huA5IJVxS5TiYykhQm7o6I3Zuo3Q==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "8.39.0",
-        "@sentry/utils": "8.39.0"
+        "@sentry/types": "8.40.0"
       },
       "engines": {
         "node": ">=14.18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.39.0.tgz",
-      "integrity": "sha512-poQBV1OG5XdESQQNT/qQzrcPBEsQIuK3kz7cE7MVOcdTqjfWGC+gVYMMjvfBrZ+A1jdLolepMLnEG80OzvHoNA==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.40.0.tgz",
+      "integrity": "sha512-UO1jWuO+z4DnK2NYCvQQfpNbfFYgeV//cNS83QIPkj9hPIEOpUR2DAfPmI9bj2Yjdh7WE8IN9Can9xDcfJquMQ==",
+      "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/context-async-hooks": "^1.25.1",
@@ -3777,10 +3784,9 @@
         "@opentelemetry/sdk-trace-base": "^1.26.0",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@prisma/instrumentation": "5.19.1",
-        "@sentry/core": "8.39.0",
-        "@sentry/opentelemetry": "8.39.0",
-        "@sentry/types": "8.39.0",
-        "@sentry/utils": "8.39.0",
+        "@sentry/core": "8.40.0",
+        "@sentry/opentelemetry": "8.40.0",
+        "@sentry/types": "8.40.0",
         "import-in-the-middle": "^1.11.2"
       },
       "engines": {
@@ -3791,6 +3797,7 @@
       "version": "0.54.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.54.2.tgz",
       "integrity": "sha512-4MTVwwmLgUh5QrJnZpYo6YRO5IBLAggf2h8gWDblwRagDStY13aEvt7gGk3jewrMaPlHiF83fENhIx0HO97/cQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
@@ -3802,6 +3809,7 @@
       "version": "0.54.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.54.2.tgz",
       "integrity": "sha512-go6zpOVoZVztT9r1aPd79Fr3OWiD4N24bCPJsIKkBses8oyFo12F/Ew3UBTdIu6hsW4HC4MVEJygG6TEyJI/lg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.54.2",
         "@types/shimmer": "^1.2.0",
@@ -3818,13 +3826,13 @@
       }
     },
     "node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.39.0.tgz",
-      "integrity": "sha512-ZnZ6zpyRPOUR6LwmvXqXK6XXDfjIXIRoX1ZVy44ZqN3XQL1Cg5n5sp0W/8T0qpKVyyEkE+AphLI/EGyp/gQLfQ==",
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.40.0.tgz",
+      "integrity": "sha512-kW9EBRESjNnBdj2zCqNMv8x0VIsmiALIOMpi25Dpm38IKtRg/ckQ7YOWx1lnT3iOFebO2GXUvOu+gPmuzIY2WQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.39.0",
-        "@sentry/types": "8.39.0",
-        "@sentry/utils": "8.39.0"
+        "@sentry/core": "8.40.0",
+        "@sentry/types": "8.40.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -3838,20 +3846,10 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.39.0.tgz",
-      "integrity": "sha512-/n1bGkbJcSLZQpzd1Oksi8LFAMbcO8j/d+N8mcXS74GuhGgkxQiEwHF2CKTz6SHt8J4hrlyzqIwVzCevUOxZ2Q==",
-      "engines": {
-        "node": ">=14.18"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "8.39.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.39.0.tgz",
-      "integrity": "sha512-pIBnr/cROds92CcYWBW3z1zFH4uJkMPL2AxEv/ZcLg/NTb1Okz/ZaDP+NMzUfzriYvFBOFk0wPk0h5sYx6Umqw==",
-      "dependencies": {
-        "@sentry/types": "8.39.0"
-      },
+      "version": "8.40.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.40.0.tgz",
+      "integrity": "sha512-nuCf3U3deolPM9BjNnwCc33UtFl9ec15/r74ngAkNccn+A2JXdIAsDkGJMO/9mgSFykLe1QyeJ0pQFRisCGOiA==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.18"
       }
@@ -8498,15 +8496,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
-    },
     "node_modules/hexoid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
@@ -10422,9 +10411,10 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.1.tgz",
-      "integrity": "sha512-VnnE19XO2Vb2oZeH8quAepfrb6Aaz4OoY8yZQACfuy/5KVJ0GxYC0Qxzz/iuc+g5UF7H0HJ+QROfvH26XeBdDA==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.2.tgz",
+      "integrity": "sha512-85RUkoYKIVB21PbMKrnD6aCl9ws+XKEyhJNMbLn206NyD3jbBo7Ec7Wi4Jrsn4dV1a2ng7K/jfkmIN0DNoS41w==",
+      "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -10988,28 +10978,6 @@
         "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
-    "node_modules/node-html-markdown": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/node-html-markdown/-/node-html-markdown-1.3.0.tgz",
-      "integrity": "sha512-OeFi3QwC/cPjvVKZ114tzzu+YoR+v9UXW5RwSXGUqGb0qCl0DvP406tzdL7SFn8pZrMyzXoisfG2zcuF9+zw4g==",
-      "license": "MIT",
-      "dependencies": {
-        "node-html-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/node-html-parser": {
-      "version": "6.1.13",
-      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
-      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^5.1.0",
-        "he": "1.2.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -11373,9 +11341,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.72.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.72.0.tgz",
-      "integrity": "sha512-hFqG9BWCs7L7ifrhJXw7mJXmUBr7d9N6If3J9563o0jfwVA4wFANFDDaOIWFdgDdwgCXg5emf0Q+LoLCGszQYA==",
+      "version": "4.73.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.73.0.tgz",
+      "integrity": "sha512-NZstV77w3CEol9KQTRBRQ15+Sw6nxVTicAULSjYO4wn9E5gw72Mtp3fAVaBFXyyVPws4241YmFG6ya4L8v03tA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -13810,6 +13779,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
       "license": "0BSD"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/type": {
       "version": "2.7.3",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
   "engines": {
     "node": "20.x.x"
   },
+  "jest": {
+    "setupFilesAfterEnv": ["./tests/jest.setup.js"]
+  },
   "dependencies": {
     "@opendocsg/pdf2md": "^0.1.31",
-    "@sentry/node": "^8.39.0",
+    "@sentry/node": "^8.40.0",
     "axios": "^1.7.7",
     "body-parser": "^1.20.2",
     "bull": "^4.16.4",
@@ -33,13 +36,12 @@
     "express-openapi-validator": "^5.3.9",
     "ioredis": "^5.4.1",
     "lodash": "^4.17.21",
-    "marked": "^15.0.1",
+    "marked": "^15.0.2",
     "nanoid": "^3.3.7",
     "nconf": "^0.12.1",
     "newrelic": "^12.8.0",
-    "node-html-markdown": "^1.3.0",
     "nunjucks": "^3.2.4",
-    "openai": "^4.72.0",
+    "openai": "^4.73.0",
     "pg": "^8.13.1",
     "pg-hstore": "^2.3.4",
     "pgvector": "^0.2.0",
@@ -49,6 +51,7 @@
     "sequelize-cli": "^6.6.2",
     "swagger-jsdoc": "^6.2.8",
     "tiktoken": "^1.0.17",
+    "turndown": "^7.2.0",
     "wink-eng-lite-web-model": "^1.8.0",
     "wink-nlp": "^2.3.0",
     "winston": "^3.17.0"

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -50,7 +50,7 @@ async function fetchAndCleanHtml(url) {
   const $ = cheerio.load(htmlContent);
 
   // Remove unnecessary elements (adjust selectors as needed)
-  $('nav, .nav, .navigation, header, footer, .footer, aside, script, style, img').remove();
+  $('svg, nav, .nav, .navigation, header, footer, .footer, aside, script, style, img, iframe').remove();
 
   // Remove empty elements
   $('body').find('*').filter(function () {

--- a/src/llms/cohere.js
+++ b/src/llms/cohere.js
@@ -34,10 +34,16 @@ const MAX_RETRIES = 10;
  * @return {*}
  */
 async function createEmbeddings({ texts, type }) {
+  if (_.isEmpty(texts)) {
+    return {
+      embeddings: [],
+      costUSD: 0,
+    };
+  }
+
   const cohere = new CohereClient(COHERE_CLIENT_CONFIG);
 
   let inputType;
-
   switch (type) {
     case 'document':
       inputType = 'search_document';
@@ -47,13 +53,6 @@ async function createEmbeddings({ texts, type }) {
       break;
     default:
       throw new Error('Invalid embeddings type');
-  }
-
-  if (process.env.NODE_ENV === 'test' || _.isEmpty(texts)) {
-    return {
-      embeddings: _.map(texts, () => _.range(0, 1024)),
-      costUSD: 0,
-    };
   }
 
   let tokens = 0;
@@ -109,14 +108,14 @@ async function createEmbeddings({ texts, type }) {
  * @return {*}
  */
 async function rerank({ query, chunks, threshold }) {
-  const cohere = new CohereClient(COHERE_CLIENT_CONFIG);
-
-  if (process.env.NODE_ENV === 'test' || _.isEmpty(chunks)) {
+  if (_.isEmpty(chunks)) {
     return {
       chunks,
       costUSD: 0,
     };
   }
+
+  const cohere = new CohereClient(COHERE_CLIENT_CONFIG);
 
   let attempt = 0;
   while (attempt < MAX_RETRIES) {
@@ -174,14 +173,6 @@ async function rerank({ query, chunks, threshold }) {
 async function inference({
   text, instructions, creativity, quality, json,
 }) {
-  if (process.env.NODE_ENV === 'test') {
-    return {
-      model: 'gpt-test',
-      output: text,
-      costUSD: 0,
-    };
-  }
-
   const cohere = new CohereClientV2(COHERE_CLIENT_CONFIG);
 
   // Prepare messages

--- a/src/v1/documents.js
+++ b/src/v1/documents.js
@@ -14,7 +14,7 @@ if (typeof Promise.withResolvers === 'undefined') {
 
 const _ = require('lodash');
 const pdf2md = require('@opendocsg/pdf2md');
-const { NodeHtmlMarkdown } = require('node-html-markdown');
+const TurndownService = require('turndown');
 const { apiRoute, notFoundResponse, badRequestResponse } = require('../helpers/responses');
 const { serializeDocument } = require('../helpers/serialize');
 const { generateRandomHash } = require('../helpers/tokens');
@@ -26,6 +26,7 @@ const { fetchAndCleanHtml } = require('../helpers/utils');
 const { SCOPE_DATA_READ, SCOPE_DATA_WRITE } = require('../scopes');
 
 const { Op } = db.Sequelize;
+const turndownService = new TurndownService();
 
 module.exports = (router) => {
   /**
@@ -312,7 +313,7 @@ module.exports = (router) => {
           break;
         case 'url':
         case 'html':
-          content = NodeHtmlMarkdown.translate(content);
+          content = turndownService.turndown(content);
           break;
         case 'text':
         case 'markdown':

--- a/tests/inference.test.js
+++ b/tests/inference.test.js
@@ -5,9 +5,6 @@ const { SCOPE_CHAT } = require('../src/scopes');
 const openai = require('../src/llms/openai');
 const cohere = require('../src/llms/cohere');
 
-jest.mock('../src/llms/openai');
-jest.mock('../src/llms/cohere');
-
 const TOKEN = 'org_chat_token';
 
 describe('Inference API', () => {

--- a/tests/jest.setup.js
+++ b/tests/jest.setup.js
@@ -1,0 +1,53 @@
+jest.mock('../src/llms/cohere', () => ({
+  createEmbeddings: jest.fn(async ({ texts }) => {
+    function range(start, end, step = 1) {
+      const result = [];
+      for (let i = start; (step > 0 ? i < end : i > end); i += step) {
+        result.push(i);
+      }
+      return result;
+    }
+    return {
+      embeddings: (texts || []).map(() => range(0, 1024)),
+      costUSD: 0,
+    };
+  }),
+
+  rerank: jest.fn(async ({ chunks }) => {
+    return {
+      chunks,
+      costUSD: 0,
+    };
+  }),
+
+  inference: jest.fn(async ({ text, json }) => {
+    return {
+      model: 'gpt',
+      output: json ? {} : text,
+      costUSD: 0,
+    };
+  }),
+}));
+
+jest.mock('../src/llms/openai', () => ({
+  inference: jest.fn(async ({ text, json }) => {
+    return {
+      model: 'gpt',
+      output: json ? {} : text,
+      costUSD: 0,
+    };
+  }),
+
+  countTokens: jest.fn((text) => {
+    return (text || '').length;
+  }),
+
+  chatStream: jest.fn(async ({ messages }) => {
+    return {
+      model: 'gpt',
+      costUSD: 0,
+      text: 'Hello',
+      messages,
+    };
+  }),
+}));


### PR DESCRIPTION
- Update the chat endpoint with a new spec that returns confidence level and other parameters for quality evaluation.
- Use `turndown` instead of `node-html-markdown`.
- Better test mocking.